### PR TITLE
lxc_attach typo (lxc_attath)

### DIFF
--- a/holodev
+++ b/holodev
@@ -141,7 +141,7 @@ create_default_configuration_file() {
   fi
 }
 
-lxc_attath() {
+lxc_attach() {
   sudo lxc-attach --clear-env -n $CONTAINER_NAME -- $@
 }
 


### PR DESCRIPTION
just a typo in the function definition

Signed-off-by: Lucas Severo lucassalves65@gmail.com
